### PR TITLE
incr -> increment

### DIFF
--- a/garrysmod/addons/igs-modification/lua/igs/mods/cashback.lua
+++ b/garrysmod/addons/igs-modification/lua/igs/mods/cashback.lua
@@ -41,7 +41,7 @@ function IGS.SetCashback(ply, month, summ)
 end
 
 function IGS.AddCashback(ply, summ, month)
-	return bib.incr(ply, getUID(ply, month), summ)
+	return bib.increment(ply, getUID(ply, month), summ)
 end
 
 function IGS.DeleteCashback(ply, month)


### PR DESCRIPTION
Предположу что это должно быть так, но после cмены incr на increment
```lua
[donate_igs-modification] igs/dependencies/bib.lua:93: attempt to perform arithmetic on a string value
  1. AddCashback - igs/dependencies/bib.lua:93
   2. fn - addons/donate_igs-modification/lua/igs/mods/cashback.lua:68
    3. Run - addons/admin_ulib/lua/ulib/shared/hook.lua:109
     4. fOnFinish_ - igs/core_sv.lua:98
      5. fOnSuccess - igs/core_sv.lua:210
       6. fOnSuccess - igs/apinator.lua:71
        7. onsuccess - igs/apinator.lua:61
         8. unknown - lua/includes/modules/http.lua:58
```

До смены было так
```lua
[donate_igs-modification] addons/donate_igs-modification/lua/igs/mods/cashback.lua:44: attempt to call field 'incr' (a nil value)
  1. AddCashback - addons/donate_igs-modification/lua/igs/mods/cashback.lua:44
   2. fn - addons/donate_igs-modification/lua/igs/mods/cashback.lua:68
    3. Run - addons/admin_ulib/lua/ulib/shared/hook.lua:109
     4. fOnFinish_ - igs/core_sv.lua:98
      5. fOnSuccess - igs/core_sv.lua:210
       6. fOnSuccess - igs/apinator.lua:71
        7. onsuccess - igs/apinator.lua:61
         8. unknown - lua/includes/modules/http.lua:58
```